### PR TITLE
node@4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
     - COMMAND=test:integration
     - COMMAND=test:e2e
     - COMMAND=coverage:upload
+
+matrix:
+  fast_finish: true
+  include:
+    - node_js: "4"
+      env: COMMAND=test:node4
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
-  get,
-  mock
+  // don’t use short syntax for node@4 compatibility
+  get: get,
+  mock: mock
 }
 
 const nock = require('nock')

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
   toObject: rawHeadersToObject,
   toArray: objectToRawHeaders
@@ -19,5 +21,5 @@ function rawHeadersToObject (rawHeaders) {
 
 function objectToRawHeaders (map) {
   const keys = Object.keys(map).sort()
-  return [].concat(...keys.map(key => [key, map[key]]))
+  return [].concat.apply([], keys.map(key => [key, map[key]]))
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "tap --coverage 'test/**/*-test.js'",
     "test:unit": "tap 'test/unit/**/*-test.js'",
     "test:integration": "tap 'test/integration/**/*-test.js'",
+    "test:node4": "node test/node-4-compatibility.js",
     "test:e2e": "test/end-to-end/server-test.sh",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
   },
   "homepage": "https://github.com/gr2m/octokit-fixtures#readme",
   "dependencies": {
-    "envalid": "^4.0.1",
-    "express": "^4.15.4",
-    "glob": "^7.1.2",
-    "http-proxy-middleware": "^0.17.4",
-    "minimist": "^1.2.0",
     "nock": "gr2m/nock#961/define-ignores-badheaders"
+  },
+  "optionalDependencies": {
+    "express": "^4.15.4",
+    "http-proxy-middleware": "^0.17.4",
+    "envalid": "^4.0.1",
+    "glob": "^7.1.2"
   },
   "devDependencies": {
     "axios": "^0.16.2",
@@ -47,6 +48,7 @@
     "coveralls": "^2.13.1",
     "humanize-string": "^1.0.1",
     "json-diff": "^0.5.1",
+    "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "semantic-release": "^7.0.2",
     "standard": "^10.0.3",

--- a/test/node-4-compatibility.js
+++ b/test/node-4-compatibility.js
@@ -1,0 +1,1 @@
+require('..').mock('api.github.com/get-organization')


### PR DESCRIPTION
this is for the node usage only. The server requires node 6 or later due to incompatibility of its dependencies (envalid). I think that’s fine, the server has a standalone binary anyway