### PR TITLE
put/patch requests with empty body

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,46 @@ For tests, you can check if all mocks have been satisfied for a given scenario
 const mock = fixtures.mock('api.github.com/get-repository')
 // send requests ...
 mock.done() // will throw an error unless all mocked routes have been called
+mock.isDone() // returns true / false
+mock.pending() // returns array of pending mocks in the format [<method> <path>]
+```
+
+`mock.explain` can be used to amend an error thrown by nock if a request could
+not be matched
+
+```js
+const mock = fixtures.mock('api.github.com/get-repository')
+const github = new GitHub()
+return github.repos.get({owner: 'octokit-fixture-org', repo: 'hello-world'})
+.catch(mock.explain)
+```
+
+Now instead of logging
+
+```
+Error: Nock: No match for request {
+  "method": "get",
+  "url": "https://api.github.com/orgs/octokit-fixture-org",
+  "headers": {
+    "host": "api.github.com",
+    "content-length": "0",
+    "user-agent": "NodeJS HTTP Client",
+    "accept": "application/vnd.github.v3+json"
+  }
+}
+```
+
+The log shows exactly what the difference between the sent request and the next
+pending mock is
+
+```diff
+ Request did not match mock:
+ {
+   headers: {
+-    accept: "application/vnd.github.v3"
++    accept: "application/vnd.github.v3+json"
+   }
+ }
 ```
 
 #### fixtures.get(scenario)

--- a/fixtures/api.github.com/add-and-remove-repository-collaborator.json
+++ b/fixtures/api.github.com/add-and-remove-repository-collaborator.json
@@ -117,9 +117,9 @@
     },
     "reqheaders": {
       "accept": "application/vnd.github.v3+json",
-      "content-type": "application/x-www-form-urlencoded",
       "authorization": "token 0000000000000000000000000000000000000000",
-      "host": "api.github.com"
+      "host": "api.github.com",
+      "content-length": 0
     },
     "headers": {
       "access-control-allow-origin": "*",
@@ -304,9 +304,9 @@
     "response": "",
     "reqheaders": {
       "accept": "application/vnd.github.v3+json",
-      "content-type": "application/x-www-form-urlencoded",
       "authorization": "token 0000000000000000000000000000000000000000",
-      "host": "api.github.com"
+      "host": "api.github.com",
+      "content-length": 0
     },
     "headers": {
       "access-control-allow-origin": "*",

--- a/lib/normalize/index.js
+++ b/lib/normalize/index.js
@@ -56,6 +56,16 @@ function normalize (fixture) {
   delete fixture.headers.server
   delete fixture.headers.vary
 
+  // The GitHub API has several endpoints that require a PUT or a PATCH verb
+  // with an empty body. In that case it’s unclear what content-type to set,
+  // or if a content-type header is to be set at all. So we remove it from our
+  // fixtures in that case but set content-length to 0 as required via:
+  // https://developer.github.com/v3/#http-verbs
+  if ((fixture.method === 'put' || fixture.method === 'patch') && !fixture.body) {
+    delete fixture.reqheaders['content-type']
+    fixture.reqheaders['content-length'] = 0
+  }
+
   const responses = Array.isArray(fixture.response) ? fixture.response : [fixture.response]
   responses.forEach(response => {
     const entityName = toEntityName(response)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/gr2m/octokit-fixtures#readme",
   "dependencies": {
+    "lodash": "^4.17.4",
     "nock": "^9.0.16"
   },
   "optionalDependencies": {

--- a/scenarios/api.github.com/add-and-remove-repository-collaborator.js
+++ b/scenarios/api.github.com/add-and-remove-repository-collaborator.js
@@ -39,6 +39,9 @@ async function addAndRemoveRepostioryCollaborator (state) {
     }
   })
 
+  // wait for 1000ms as there seems to be a race condition on GitHub’s API
+  await new Promise(resolve => setTimeout(resolve, 1000))
+
   // https://developer.github.com/v3/repos/collaborators/#list-collaborators
   await state.request({
     method: 'get',


### PR DESCRIPTION
The GitHub API has several endpoints that require a PUT or a PATCH verb
with an empty body. In that case it’s unclear what content-type to set,
or if a content-type header is to be set at all. So we remove it from our
fixtures in that case but set content-length to 0 as required via:
https://developer.github.com/v3/#http-verbs